### PR TITLE
travel_planの一覧画面まで実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ end
 gem 'rubocop'
 
 gem 'sorcery'
+
+gem 'enumerize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     drb (2.2.1)
+    enumerize (2.8.1)
+      activesupport (>= 3.2)
     erubi (1.13.0)
     faraday (2.10.1)
       faraday-net_http (>= 2.0, < 3.2)
@@ -313,6 +315,7 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  enumerize
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,6 @@
+class TasksController < ApplicationController
+  def index
+    @travel_plan = TravelPlan.find(params[:travel_plan_id])
+    @tasks = @travel_plan.tasks
+  end
+end

--- a/app/controllers/travel_plans_controller.rb
+++ b/app/controllers/travel_plans_controller.rb
@@ -1,0 +1,5 @@
+class TravelPlansController < ApplicationController
+    def index
+      @travel_plans = TravelPlan.all
+    end
+end

--- a/app/controllers/travel_plans_controller.rb
+++ b/app/controllers/travel_plans_controller.rb
@@ -2,4 +2,17 @@ class TravelPlansController < ApplicationController
     def index
       @travel_plans = TravelPlan.all
     end
+
+    def new
+      @travel_plan = TravelPlan.new
+    end
+
+    def create
+      @travel_plan = current_user.travel_plans.build(travel_plan_params)
+      if @travel_plan.save
+        redirect_to travel_plans_path
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
 end

--- a/app/controllers/travel_plans_controller.rb
+++ b/app/controllers/travel_plans_controller.rb
@@ -15,4 +15,10 @@ class TravelPlansController < ApplicationController
         render :new, status: :unprocessable_entity
       end
     end
+
+    private
+
+    def travel_plan_params
+      params.require(:travel_plan).permit(:title, :country, :note, :due)
+    end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,8 @@
+class Task < ApplicationRecord
+  extend Enumerize
+  enumerize :status, in: %i(pending working done)
+  enumerize :baggage, in: %i(carry leave)
+
+  belongs_to :travel_plan
+  belongs_to :user
+end

--- a/app/models/travel_plan.rb
+++ b/app/models/travel_plan.rb
@@ -1,0 +1,4 @@
+class TravelPlan < ApplicationRecord
+  belongs_to :user
+  has_many :tasks, dependent: :destroy
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
+
+  has_many :travel_plans, dependent: :destroy
+  has_many :tasks, dependent: :destroy
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,6 +9,7 @@
       </span>
     </a>
     <nav class="md:ml-auto md:mr-auto flex flex-wrap items-center text-base justify-center">
+      <%= link_to "タスク作成", new_travel_plan_path, class: "mr-5 hover:text-gray-900" %>
       <%= link_to "タスク一覧", travel_plans_path, class: "mr-5 hover:text-gray-900" %>
       <a class="mr-5 hover:text-gray-900">Tips</a>
       <a class="mr-5 hover:text-gray-900">サイトの使い方</a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,10 +4,12 @@
       <div>
         <%= image_tag 'logo.png', alt: 'Logo', class: 'w-20 h-20 p-2' %>
       </div>
-      <span class="ml-3 text-xl">Packing Checker</span>
+      <span>
+      <%= link_to "Packing Checker", root_path, class: "ml-3 text-xl text-black" %>
+      </span>
     </a>
     <nav class="md:ml-auto md:mr-auto flex flex-wrap items-center text-base justify-center">
-      <a class="mr-5 hover:text-gray-900">タスク一覧</a>
+      <%= link_to "タスク一覧", travel_plans_path, class: "mr-5 hover:text-gray-900" %>
       <a class="mr-5 hover:text-gray-900">Tips</a>
       <a class="mr-5 hover:text-gray-900">サイトの使い方</a>
       <%= link_to "ログアウト", logout_path, class: "mr-5 hover:text-gray-900", data: { turbo_method: :delete } %>

--- a/app/views/travel_plans/_form.html.erb
+++ b/app/views/travel_plans/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with model: travel_plan do |f| %>
+  <div class="p-2 w-full">
+    <div class="relative">
+      <div class="mb-3">
+        <%= f.label "旅行タイトル" %>
+        <%= f.text_field :title, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" %>
+      </div>
+    </div>
+  </div>
+  <div class="p-2 w-full">
+    <div class="relative">
+      <div class="mb-3">
+          <%= f.label "行き先", class: "leading-7 text-sm text-gray-600" %>
+          <%= f.text_field :country, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" %>
+      </div>
+    </div>
+  </div>
+  <div class="p-2 w-full">
+    <div class="relative">
+      <div class="mb-3">
+        <%= f.label "メモ", class: "leading-7 text-sm text-gray-600" %>
+        <%= f.text_area :note, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 h-32 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out" %>
+      </div>
+    </div>
+  </div>
+  <div class="p-2 w-full">
+    <div class="relative">
+      <div class="mb-3">
+        <%= f.label "出発日", class: "leading-7 text-sm text-gray-600" %>
+        <%= f.date_field :due, class: "w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out" %>
+      </div>
+    </div>
+  </div>
+  <div class="p-2 w-full">
+    <%= f.submit nil, class: "flex mx-auto text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg" %>
+  </div>
+<% end %>

--- a/app/views/travel_plans/_travel_plan.html.erb
+++ b/app/views/travel_plans/_travel_plan.html.erb
@@ -1,0 +1,20 @@
+<div class="py-8 flex flex-wrap md:flex-nowrap">
+  <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
+    <span class="font-semibold title-font text-gray-700">TRAVEL PLAN</span>
+    <div class="mt-1 text-gray-500 text-sm">
+      <h3>出発日</h3>
+      <span><%= travel_plan.due %></span>
+    </div>
+  </div>
+  <div class="md:flex-grow">
+    <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">
+      <%= link_to travel_plan.title, travel_plan_tasks_path(travel_plan) %>
+    </h2>
+    <p class="leading-relaxed">
+      <%= travel_plan.note %>
+    </p>
+    <p class="text-indigo-500 inline-flex items-center mt-4">
+      <%= travel_plan.country %>
+    </p>
+  </div>
+</div>

--- a/app/views/travel_plans/index.html.erb
+++ b/app/views/travel_plans/index.html.erb
@@ -1,0 +1,54 @@
+<section class="text-gray-600 body-font overflow-hidden">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="-my-8 divide-y-2 divide-gray-100">
+      <div class="py-8 flex flex-wrap md:flex-nowrap">
+        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
+          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
+          <span class="mt-1 text-gray-500 text-sm">12 Jun 2019</span>
+        </div>
+        <div class="md:flex-grow">
+          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Bitters hashtag waistcoat fashion axe chia unicorn</h2>
+          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
+          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
+            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M5 12h14"></path>
+              <path d="M12 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div class="py-8 flex flex-wrap md:flex-nowrap">
+        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
+          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
+          <span class="mt-1 text-gray-500 text-sm">12 Jun 2019</span>
+        </div>
+        <div class="md:flex-grow">
+          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Meditation bushwick direct trade taxidermy shaman</h2>
+          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
+          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
+            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M5 12h14"></path>
+              <path d="M12 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+      </div>
+      <div class="py-8 flex flex-wrap md:flex-nowrap">
+        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
+          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
+          <span class="text-sm text-gray-500">12 Jun 2019</span>
+        </div>
+        <div class="md:flex-grow">
+          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Woke master cleanse drinking vinegar salvia</h2>
+          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
+          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
+            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M5 12h14"></path>
+              <path d="M12 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/travel_plans/index.html.erb
+++ b/app/views/travel_plans/index.html.erb
@@ -1,54 +1,7 @@
 <section class="text-gray-600 body-font overflow-hidden">
   <div class="container px-5 py-24 mx-auto">
     <div class="-my-8 divide-y-2 divide-gray-100">
-      <div class="py-8 flex flex-wrap md:flex-nowrap">
-        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
-          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
-          <span class="mt-1 text-gray-500 text-sm">12 Jun 2019</span>
-        </div>
-        <div class="md:flex-grow">
-          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Bitters hashtag waistcoat fashion axe chia unicorn</h2>
-          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
-          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
-            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M5 12h14"></path>
-              <path d="M12 5l7 7-7 7"></path>
-            </svg>
-          </a>
-        </div>
-      </div>
-      <div class="py-8 flex flex-wrap md:flex-nowrap">
-        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
-          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
-          <span class="mt-1 text-gray-500 text-sm">12 Jun 2019</span>
-        </div>
-        <div class="md:flex-grow">
-          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Meditation bushwick direct trade taxidermy shaman</h2>
-          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
-          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
-            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M5 12h14"></path>
-              <path d="M12 5l7 7-7 7"></path>
-            </svg>
-          </a>
-        </div>
-      </div>
-      <div class="py-8 flex flex-wrap md:flex-nowrap">
-        <div class="md:w-64 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
-          <span class="font-semibold title-font text-gray-700">CATEGORY</span>
-          <span class="text-sm text-gray-500">12 Jun 2019</span>
-        </div>
-        <div class="md:flex-grow">
-          <h2 class="text-2xl font-medium text-gray-900 title-font mb-2">Woke master cleanse drinking vinegar salvia</h2>
-          <p class="leading-relaxed">Glossier echo park pug, church-key sartorial biodiesel vexillologist pop-up snackwave ramps cornhole. Marfa 3 wolf moon party messenger bag selfies, poke vaporware kombucha lumbersexual pork belly polaroid hoodie portland craft beer.</p>
-          <a class="text-indigo-500 inline-flex items-center mt-4">Learn More
-            <svg class="w-4 h-4 ml-2" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M5 12h14"></path>
-              <path d="M12 5l7 7-7 7"></path>
-            </svg>
-          </a>
-        </div>
-      </div>
+      <%= render @travel_plans %>
     </div>
   </div>
 </section>

--- a/app/views/travel_plans/new.html.erb
+++ b/app/views/travel_plans/new.html.erb
@@ -1,0 +1,62 @@
+<section class="text-gray-600 body-font relative">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-col text-center w-full mb-12">
+      <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">Contact Us</h1>
+      <p class="lg:w-2/3 mx-auto leading-relaxed text-base">Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical gentrify.</p>
+    </div>
+    <div class="lg:w-1/2 md:w-2/3 mx-auto">
+      <div class="flex flex-wrap -m-2">
+        <div class="p-2 w-1/2">
+          <div class="relative">
+            <label for="name" class="leading-7 text-sm text-gray-600">Name</label>
+            <input type="text" id="name" name="name" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+          </div>
+        </div>
+        <div class="p-2 w-1/2">
+          <div class="relative">
+            <label for="email" class="leading-7 text-sm text-gray-600">Email</label>
+            <input type="email" id="email" name="email" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
+          </div>
+        </div>
+        <div class="p-2 w-full">
+          <div class="relative">
+            <label for="message" class="leading-7 text-sm text-gray-600">Message</label>
+            <textarea id="message" name="message" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 h-32 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out"></textarea>
+          </div>
+        </div>
+        <div class="p-2 w-full">
+          <button class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">Button</button>
+        </div>
+        <div class="p-2 w-full pt-8 mt-8 border-t border-gray-200 text-center">
+          <a class="text-indigo-500">example@email.com</a>
+          <p class="leading-normal my-5">49 Smith St.
+            <br>Saint Cloud, MN 56301
+          </p>
+          <span class="inline-flex">
+            <a class="text-gray-500">
+              <svg fill="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
+                <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"></path>
+              </svg>
+            </a>
+            <a class="ml-4 text-gray-500">
+              <svg fill="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
+                <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path>
+              </svg>
+            </a>
+            <a class="ml-4 text-gray-500">
+              <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
+                <rect width="20" height="20" x="2" y="2" rx="5" ry="5"></rect>
+                <path d="M16 11.37A4 4 0 1112.63 8 4 4 0 0116 11.37zm1.5-4.87h.01"></path>
+              </svg>
+            </a>
+            <a class="ml-4 text-gray-500">
+              <svg fill="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
+                <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>
+              </svg>
+            </a>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/travel_plans/new.html.erb
+++ b/app/views/travel_plans/new.html.erb
@@ -1,32 +1,11 @@
 <section class="text-gray-600 body-font relative">
   <div class="container px-5 py-24 mx-auto">
     <div class="flex flex-col text-center w-full mb-12">
-      <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">Contact Us</h1>
-      <p class="lg:w-2/3 mx-auto leading-relaxed text-base">Whatever cardigan tote bag tumblr hexagon brooklyn asymmetrical gentrify.</p>
+      <h1 class="sm:text-3xl text-2xl font-medium title-font mb-4 text-gray-900">どんな旅行プランですか？</h1>
     </div>
     <div class="lg:w-1/2 md:w-2/3 mx-auto">
-      <div class="flex flex-wrap -m-2">
-        <div class="p-2 w-1/2">
-          <div class="relative">
-            <label for="name" class="leading-7 text-sm text-gray-600">Name</label>
-            <input type="text" id="name" name="name" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-          </div>
-        </div>
-        <div class="p-2 w-1/2">
-          <div class="relative">
-            <label for="email" class="leading-7 text-sm text-gray-600">Email</label>
-            <input type="email" id="email" name="email" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 text-base outline-none text-gray-700 py-1 px-3 leading-8 transition-colors duration-200 ease-in-out">
-          </div>
-        </div>
-        <div class="p-2 w-full">
-          <div class="relative">
-            <label for="message" class="leading-7 text-sm text-gray-600">Message</label>
-            <textarea id="message" name="message" class="w-full bg-gray-100 bg-opacity-50 rounded border border-gray-300 focus:border-indigo-500 focus:bg-white focus:ring-2 focus:ring-indigo-200 h-32 text-base outline-none text-gray-700 py-1 px-3 resize-none leading-6 transition-colors duration-200 ease-in-out"></textarea>
-          </div>
-        </div>
-        <div class="p-2 w-full">
-          <button class="flex mx-auto text-white bg-indigo-500 border-0 py-2 px-8 focus:outline-none hover:bg-indigo-600 rounded text-lg">Button</button>
-        </div>
+      <div class="flex-wrap -m-2">
+        <%= render 'form', travel_plan: @travel_plan %>
         <div class="p-2 w-full pt-8 mt-8 border-t border-gray-200 text-center">
           <a class="text-indigo-500">example@email.com</a>
           <p class="leading-normal my-5">49 Smith St.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,9 @@ Rails.application.routes.draw do
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'
+
+  resources :travel_plans do
+    resources :tasks, only: [:index]
+  end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   root 'static_pages#top'
   resources :users, only: %i[new create]
+  resources :travel_plans, only: %i[index new create show edit destroy update]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240806142954_create_travel_plans.rb
+++ b/db/migrate/20240806142954_create_travel_plans.rb
@@ -1,0 +1,14 @@
+class CreateTravelPlans < ActiveRecord::Migration[7.1]
+  def change
+    create_table :travel_plans do |t|
+      t.string :title, null: false
+      t.string :country
+      t.text :note
+      t.date :due
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end
+ 

--- a/db/migrate/20240806150644_create_tasks.rb
+++ b/db/migrate/20240806150644_create_tasks.rb
@@ -1,0 +1,15 @@
+class CreateTasks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tasks do |t|
+      t.string :title, null: false
+      t.text :body
+      t.date :due
+      t.string :status, null: false, default: :pending
+      t.string :baggage, null: false, default: :carry
+      t.references :user, foreign_key: true
+      t.references :travel_plan, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240806152803_add_tasks_to_travel_plans.rb
+++ b/db/migrate/20240806152803_add_tasks_to_travel_plans.rb
@@ -1,0 +1,5 @@
+class AddTasksToTravelPlans < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :travel_plans, :task, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20240806) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_06_152803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "tasks", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body"
+    t.date "due"
+    t.string "status", default: "pending", null: false
+    t.string "baggage", default: "carry", null: false
+    t.bigint "user_id"
+    t.bigint "travel_plan_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["travel_plan_id"], name: "index_tasks_on_travel_plan_id"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
+  end
+
+  create_table "travel_plans", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "country"
+    t.text "note"
+    t.date "due"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "task_id"
+    t.index ["task_id"], name: "index_travel_plans_on_task_id"
+    t.index ["user_id"], name: "index_travel_plans_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -24,4 +51,8 @@ ActiveRecord::Schema[7.1].define(version: 20240806) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "tasks", "travel_plans"
+  add_foreign_key "tasks", "users"
+  add_foreign_key "travel_plans", "tasks"
+  add_foreign_key "travel_plans", "users"
 end


### PR DESCRIPTION
【テーブル作成】
・TravelPlansテーブル
　　プランのタイトル、行先の国、メモ、出発日
・Tasksテーブル
　　タスクのタイトル、内容、期限日、状態（実行中・保留中・実行済み）、荷物の種類（手荷物・預け荷物）
【travel_plan一覧ページ】
ヘッダーのタスク一覧を押すことで、プランの一覧が表示される。
プランのタイトルはタスクの一覧への導線になっている。
【travel_plan新規作成】
ヘッダーのタスク作成を押すことで、プラン作成ページに移行。
作成後はプラン一覧にリダイレクトする。